### PR TITLE
Skip after() if is cancelled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Maven projects
 /computation-mpi/target/
 /computation-slurm/target/
-/computation-slurm-tests/target/
+/computation-slurm-test/target/
 /distribution-hpc/target/
 /target
 

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
@@ -148,7 +148,7 @@ public class SlurmUnitTests {
                 // normal tests
                 failed = true;
             }
-            if (!e.getMessage().equals(expected)) {
+            if (!e.getCause().getMessage().equals(expected)) {
                 failed = true;
                 System.out.println(FAILED_SEP);
                 System.out.println("Actuel:" + e.getMessage());
@@ -492,8 +492,15 @@ public class SlurmUnitTests {
         TestAttribute testAttribute = new TestAttribute(Type.TO_WAIT, "deadline", true);
         Supplier<AbstractExecutionHandler<Void>> supplier = () -> new AbstractExecutionHandler<Void>() {
             @Override
-            public List<CommandExecution> before(Path workingDir) {
-                return longProgram(10);
+            public List<CommandExecution> before(Path workingDir) throws IOException {
+                return CommandExecutionsTestFactory.longProgram(10);
+            }
+
+            @Override
+            public Void after(Path workingDir, ExecutionReport report) throws IOException {
+                System.out.println("in deadline after");
+                failed = report.getErrors().isEmpty();
+                return null;
             }
         };
         ComputationParametersBuilder builder = new ComputationParametersBuilder();

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
@@ -548,7 +548,6 @@ public class SlurmUnitTests {
         System.out.println("------------------------------------");
     }
 
-
     private static class TestAttribute {
 
         private final Type type;

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/FlagFilesMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/FlagFilesMonitor.java
@@ -53,7 +53,7 @@ class FlagFilesMonitor implements Runnable {
                         commandRunner.execute("rm " + flagDir + "/" + line);
                         // cancel following jobs(which depends on this job) if there are errors
                         if (line.startsWith("myerror_")) {
-                            taskStore.getCompletableFuture(workingDirName).cancel(true);
+                            taskStore.getCompletableFuture(workingDirName).cancelBySlurm(new SlurmException("An error job found"));
                         } else if (line.startsWith("mydone_")) {
                             String id = line.substring(lastIdx + 1);
                             taskStore.untracing(Long.parseLong(id));

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
@@ -9,8 +9,10 @@ package com.powsybl.computation.slurm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -54,7 +56,7 @@ public class ScontrolMonitor implements Runnable {
                 try {
                     scontrolResult = scontrolCmd.send(commandRunner);
                     SlurmConstants.JobState jobState = scontrolResult.getJobState();
-                    boolean unmoral = false;
+                    boolean unormal = false;
                     switch (jobState) {
                         case RUNNING:
                         case PENDING:
@@ -63,10 +65,10 @@ public class ScontrolMonitor implements Runnable {
                         case TIMEOUT:
                         case DEADLINE:
                         case CANCELLED:
-                            unmoral = true;
+                            unormal = true;
                             LOGGER.info("JobId: {} is {}", id, jobState);
-                            Optional<CompletableFuture> unormalFuture = taskStore.getCompletableFutureByJobId(id);
-                            unormalFuture.ifPresent(completableFuture -> completableFuture.cancel(true));
+                            Optional<SlurmComputationManager.SlurmCompletableFuture> unormalFuture = taskStore.getCompletableFutureByJobId(id);
+                            unormalFuture.ifPresent(f -> f.cancelBySlurm(new SlurmException("A " + jobState + " job detected by monitor")));
                             break;
                         case COMPLETE:
                             // this monitor found task finished before flagDirMonitor
@@ -76,7 +78,7 @@ public class ScontrolMonitor implements Runnable {
                         default:
                             LOGGER.warn("Not implemented yet {}", jobState);
                     }
-                    if (unmoral) {
+                    if (unormal) {
                         break; // restart
                     }
                 } catch (SlurmCmdNonZeroException e) {

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
@@ -56,7 +56,7 @@ public class ScontrolMonitor implements Runnable {
                 try {
                     scontrolResult = scontrolCmd.send(commandRunner);
                     SlurmConstants.JobState jobState = scontrolResult.getJobState();
-                    boolean unormal = false;
+                    boolean abnormal = false;
                     switch (jobState) {
                         case RUNNING:
                         case PENDING:
@@ -65,7 +65,7 @@ public class ScontrolMonitor implements Runnable {
                         case TIMEOUT:
                         case DEADLINE:
                         case CANCELLED:
-                            unormal = true;
+                            abnormal = true;
                             LOGGER.info("JobId: {} is {}", id, jobState);
                             Optional<SlurmComputationManager.SlurmCompletableFuture> unormalFuture = taskStore.getCompletableFutureByJobId(id);
                             unormalFuture.ifPresent(f -> f.cancelBySlurm(new SlurmException("A " + jobState + " job detected by monitor")));
@@ -78,7 +78,7 @@ public class ScontrolMonitor implements Runnable {
                         default:
                             LOGGER.warn("Not implemented yet {}", jobState);
                     }
-                    if (unormal) {
+                    if (abnormal) {
                         break; // restart
                     }
                 } catch (SlurmCmdNonZeroException e) {

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolMonitorTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolMonitorTest.java
@@ -55,11 +55,11 @@ public class ScontrolMonitorTest {
 
     @Before
     public void setup() {
-        SlurmComputationManager.Mycf mycf;
+        SlurmComputationManager.SlurmCompletableFuture slurmCompletableFuture;
         slurm = mock(SlurmComputationManager.class);
-        mycf = new SlurmComputationManager.Mycf(slurm);
-        mycf.setThread(new Thread());
-        ts = TaskStoreTest.generateTaskStore(mycf, false);
+        slurmCompletableFuture = new SlurmComputationManager.SlurmCompletableFuture(slurm);
+        slurmCompletableFuture.setThread(new Thread());
+        ts = TaskStoreTest.generateTaskStore(slurmCompletableFuture, false);
         Whitebox.setInternalState(slurm, "taskStore", ts);
         when(slurm.getTaskStore()).thenReturn(ts);
         cm = mock(CommandExecutor.class);

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/TaskStoreTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/TaskStoreTest.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -56,7 +55,7 @@ public class TaskStoreTest {
     // 3←4,5
     // ↑
     // 6
-    static TaskStore generateTaskStore(CompletableFuture future, boolean checkTracing) {
+    static TaskStore generateTaskStore(SlurmComputationManager.SlurmCompletableFuture future, boolean checkTracing) {
         String workingDir = "a_working_dir";
         TaskCounter counter = mock(TaskCounter.class);
 
@@ -91,7 +90,7 @@ public class TaskStoreTest {
 
     @Test
     public void test() {
-        TaskStore taskStore = generateTaskStore(mock(CompletableFuture.class), false);
+        TaskStore taskStore = generateTaskStore(mock(SlurmComputationManager.SlurmCompletableFuture.class), false);
         assertEquals(Arrays.asList(3L, 6L), taskStore.getDependentJobs(1L));
         assertEquals(Collections.singletonList(6L), taskStore.getDependentJobs(3L));
         assertTrue(taskStore.getDependentJobs(6L).isEmpty());
@@ -102,13 +101,13 @@ public class TaskStoreTest {
 
     @Test
     public void testRemove() {
-        CompletableFuture future = mock(CompletableFuture.class);
+        SlurmComputationManager.SlurmCompletableFuture future = mock(SlurmComputationManager.SlurmCompletableFuture.class);
         TaskStore taskStore = generateTaskStore(future, false);
         assertEquals(1L, taskStore.getFirstJobId(future).longValue());
         assertNotNull(taskStore.getTaskCounter(future));
         assertEquals(future, taskStore.getCompletableFuture("a_working_dir"));
 
-        taskStore.remove(future);
+        taskStore.clearBy(future);
 
         assertNull(taskStore.getTaskCounter(future));
         assertNull(taskStore.getFirstJobId(future));
@@ -121,7 +120,7 @@ public class TaskStoreTest {
 
     @Test
     public void testGetFutureFromJobId() {
-        CompletableFuture future = mock(CompletableFuture.class);
+        SlurmComputationManager.SlurmCompletableFuture future = mock(SlurmComputationManager.SlurmCompletableFuture.class);
         TaskStore taskStore = generateTaskStore(future, false);
         assertEquals(future, taskStore.getCompletableFutureByJobId(1L).orElse(null));
         assertEquals(future, taskStore.getCompletableFutureByJobId(2L).orElse(null));
@@ -133,6 +132,6 @@ public class TaskStoreTest {
 
     @Test
     public void testTracing() {
-        generateTaskStore(mock(CompletableFuture.class), true);
+        generateTaskStore(mock(SlurmComputationManager.SlurmCompletableFuture.class), true);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix bug.
The ExecutionHandler's after() would be skipped if the task is cancelled by client side(ex: future.cancel()).


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
