### PR TITLE
Fix UnsatisfiedLinkError in master.so

### DIFF
--- a/mpi-communication/CMakeLists.txt
+++ b/mpi-communication/CMakeLists.txt
@@ -36,6 +36,7 @@ target_include_directories(common
 # master library
 set(MASTER_SOURCES
     src/jniutil.cpp
+    src/jniwrapper.cpp
     src/master.cpp
 )
 add_library(master SHARED ${MASTER_SOURCES})


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
At startup, there is an UnsatisfiedLinkError
```
Exception in thread "main" java.lang.UnsatisfiedLinkError: /home/funfrockmar/powsybl/lib/libmaster.so: /home/funfrockmar/powsybl/lib/libmaster.so: undefined symbol: _ZN7powsybl3jni12JavaUtilList12_addMethodIdE
         at java.lang.ClassLoader$NativeLibrary.load(Native Method)
         at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
         at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1857)
         at java.lang.Runtime.loadLibrary0(Runtime.java:870)
         at java.lang.System.loadLibrary(System.java:1122)
         at com.powsybl.computation.mpi.JniMpiNativeServices.<clinit>(JniMpiNativeServices.java:17)
         at com.powsybl.computation.mpi.MpiComputationManager.<init>(MpiComputationManager.java:55)
         at com.powsybl.computation.mpi.MpiToolUtil.createMpiComputationManager(MpiToolUtil.java:88)
         at com.powsybl.computation.mpi.MpiMaster$1.createComputationManager(MpiMaster.java:56)
         at com.powsybl.computation.mpi.MpiMaster$1.createShortTimeExecutionComputationManager(MpiMaster.java:63)
         at com.powsybl.tools.CommandLineTools.run(CommandLineTools.java:162)
         at com.powsybl.computation.mpi.MpiMaster.main(MpiMaster.java:71)
```


**What is the new behavior (if this is a feature change)?**
The `master.so` library is loaded properly


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
