### PR TITLE
Add timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Maven projects
 /computation-mpi/target/
 /computation-slurm/target/
-/computation-slurm-tests/target/
+/computation-slurm-test/target/
 /distribution-hpc/target/
 /target
 

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
@@ -438,21 +438,21 @@ public class SlurmUnitTests {
 
     // sacctmgr show qos
     @Test
-    public void testQos() throws InterruptedException {
+    public void testParameters() throws InterruptedException {
         String qos = "itesla"; //TODO the qos name should be configured
-        testQos(qos);
+        testParameters(qos);
     }
 
     @Test
     public void testInvalidQos() {
         try {
-            testQos("THIS_QOS_SHOULD_NOT_EXIST_IN_SLURM");
+            testParameters("THIS_QOS_SHOULD_NOT_EXIST_IN_SLURM");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Invalid qos specification"));
         }
     }
 
-    private void testQos(String qos) throws InterruptedException {
+    private void testParameters(String qos) throws InterruptedException {
         TestAttribute testAttribute = new TestAttribute(Type.TO_WAIT, "qos");
         Supplier<AbstractExecutionHandler<Void>> supplier = () -> new AbstractExecutionHandler<Void>() {
             @Override
@@ -460,7 +460,7 @@ public class SlurmUnitTests {
                 return CommandExecutionsTestFactory.longProgram(10);
             }
         };
-        ComputationParameters parameters = ComputationParameters.empty();
+        ComputationParameters parameters = new ComputationParametersBuilder().setTimeout("longProgram", 60).build();
         SlurmComputationParameters slurmComputationParameters = new SlurmComputationParameters(parameters, qos);
         parameters.addExtension(SlurmComputationParameters.class, slurmComputationParameters);
         baseTest(testAttribute, supplier, parameters);

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdBuilder.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdBuilder.java
@@ -123,6 +123,10 @@ class SbatchCmdBuilder {
         return this;
     }
 
+    SbatchCmdBuilder timeout(long seconds) {
+        return timeout(SlurmUtils.toTime(seconds));
+    }
+
     SbatchCmdBuilder deadline(long seconds) {
         Preconditions.checkArgument(seconds > 0, "Invalid seconds({}) for deadline: must be 1 or greater", seconds);
         sbatchArgsByName.put("deadline", String.format(DATETIME_FORMATTER, seconds));

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
@@ -515,6 +515,7 @@ public class SlurmComputationManager implements ComputationManager {
             extension.getQos().ifPresent(builder::qos);
         }
         baseParams.getDeadline(commandId).ifPresent(builder::deadline);
+        baseParams.getTimeout(commandId).ifPresent(builder::timeout);
         return builder.build();
     }
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmUtils.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmUtils.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.computation.slurm;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Yichen TANG <yichen.tang at rte-france.com>
+ */
+final class SlurmUtils {
+
+    private static final Long MINUTE = 60L;
+    private static final Long HOUR = 3600L;
+    private static final Long DAY = 86400L;
+
+    /**
+     * Seconds to parse and return an acceptable time format in String.
+     * Used in --time.
+     * @see <a href="https://slurm.schedmd.com/sbatch.html">https://slurm.schedmd.com/sbatch.html</a>
+     * @param seconds Should be greater than 0.
+     * @return Acceptable time format.
+     */
+    static String toTime(long seconds) {
+        Preconditions.checkArgument(seconds > 0 && seconds < DAY * 100, "Time limit (%s) Should be greater than 0 and less than 100 days", seconds);
+        long days = seconds / DAY;
+        long hours = (seconds - days * DAY) / HOUR;
+        long minutes = (seconds % HOUR) / MINUTE;
+        long secs = seconds % MINUTE;
+        return String.format("%02d-%02d:%02d:%02d", days, hours, minutes, secs);
+    }
+
+    private SlurmUtils() {
+    }
+}

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmUtilsTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmUtilsTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.computation.slurm;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Yichen TANG <yichen.tang at rte-france.com>
+ */
+public class SlurmUtilsTest {
+
+    @Test
+    public void test() {
+        assertEquals("00-00:00:01", SlurmUtils.toTime(1));
+        assertEquals("00-00:01:00", SlurmUtils.toTime(60));
+        assertEquals("00-00:01:01", SlurmUtils.toTime(61));
+        assertEquals("00-01:00:00", SlurmUtils.toTime(3600));
+        assertEquals("01-00:00:00", SlurmUtils.toTime(3600 * 24));
+        assertEquals("99-23:59:59", SlurmUtils.toTime(3600 * 24 * 100 - 1));
+        try {
+            SlurmUtils.toTime(0);
+            fail();
+        } catch (Exception ignored) {
+            // ignored
+        }
+        try {
+            SlurmUtils.toTime(3600 * 24 * 100);
+            fail();
+        } catch (Exception ignored) {
+            // ignored
+        }
+    }
+}


### PR DESCRIPTION
Convert timeout parameters to sbatch's --time.

Signed-off-by: yichen88 <tang.yichenyves@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#13 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
The `timeout` parameter is ignored in current slurm.


**What is the new behavior (if this is a feature change)?**
`Timeout` is converted to sbaltch --time option.  [https://slurm.schedmd.com/sbatch.html](sbatch)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
