### PR TITLE
Fix NPE on taskCounter

### DIFF
--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmUnitTests.java
@@ -88,7 +88,7 @@ public class SlurmUnitTests {
                     System.out.println("Canceled:" + completableFuture.isCancelled());
                 } else {
                     System.out.println("to cancel");
-                    Thread.sleep(5000);
+                    TimeUnit.SECONDS.sleep(5);
                     boolean cancel = completableFuture.cancel(true);
                     System.out.println("Canceled:" + cancel);
                     Assert.assertTrue(cancel);
@@ -305,6 +305,23 @@ public class SlurmUnitTests {
         Supplier<AbstractExecutionHandler<Void>> supplier = () -> new AbstractExecutionHandler<Void>() {
             @Override
             public List<CommandExecution> before(Path workingDir) {
+                return mixedProgsToCancel();
+            }
+        };
+        baseTest(testAttribute, supplier);
+    }
+
+    @Test
+    public void testCancelBeforeFirstJob() throws InterruptedException {
+        TestAttribute testAttribute = new TestAttribute(Type.TO_CANCEL, "cancelBeforeFirstJob");
+        Supplier<AbstractExecutionHandler<Void>> supplier = () -> new AbstractExecutionHandler<Void>() {
+            @Override
+            public List<CommandExecution> before(Path workingDir) {
+                try {
+                    TimeUnit.SECONDS.sleep(6);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
                 return mixedProgsToCancel();
             }
         };

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
@@ -308,11 +308,12 @@ public class SlurmComputationManager implements ComputationManager {
             remoteWorkingDir = remoteWorkingDirectory.toPath();
 
             taskStore.insert(remoteWorkingDir.getFileName().toString(), f);
+            TaskCounter taskCounter = new TaskCounter();
+            taskStore.insert(remoteWorkingDir.getFileName().toString(), taskCounter);
             List<CommandExecution> commandExecutions = handler.before(remoteWorkingDir);
 
             int sum = commandExecutions.stream().mapToInt(CommandExecution::getExecutionCount).sum();
-            TaskCounter taskCounter = new TaskCounter(sum);
-            taskStore.insert(remoteWorkingDir.getFileName().toString(), taskCounter);
+            taskCounter.setCount(sum);
 
             Map<Long, Command> jobIdCommandMap;
             jobIdCommandMap = generateSbatchAndSubmit(commandExecutions, parameters, remoteWorkingDir, environment, f);

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
@@ -312,9 +312,10 @@ public class SlurmComputationManager implements ComputationManager {
 
             int sum = commandExecutions.stream().mapToInt(CommandExecution::getExecutionCount).sum();
             TaskCounter taskCounter = new TaskCounter(sum);
+            taskStore.insert(remoteWorkingDir.getFileName().toString(), taskCounter);
 
             Map<Long, Command> jobIdCommandMap;
-            jobIdCommandMap = generateSbatchAndSubmit(commandExecutions, parameters, remoteWorkingDir, environment, taskCounter, f);
+            jobIdCommandMap = generateSbatchAndSubmit(commandExecutions, parameters, remoteWorkingDir, environment, f);
 
             // waiting task finish
             try {
@@ -373,7 +374,7 @@ public class SlurmComputationManager implements ComputationManager {
     }
 
     private Map<Long, Command> generateSbatchAndSubmit(List<CommandExecution> commandExecutions, ComputationParameters parameters, Path workingDir,
-                                                       ExecutionEnvironment environment, TaskCounter taskCounter, CompletableFuture<?> future)
+                                                       ExecutionEnvironment environment, CompletableFuture<?> future)
             throws IOException {
         Map<Long, Command> jobIdCommandMap = new HashMap<>();
         Long firstJobId = null; // the first jobId submitted of List<CommandExecution>
@@ -405,7 +406,7 @@ public class SlurmComputationManager implements ComputationManager {
                     long jobId = launchSbatch(cmd);
                     if (firstJobId == null) {
                         firstJobId = jobId;
-                        taskStore.insert(workingDir.getFileName().toString(), taskCounter, firstJobId);
+                        taskStore.insert(workingDir.getFileName().toString(), firstJobId);
                         LOGGER.debug("First jobid : {}", firstJobId);
                     }
                     if (preMasterJobId != null) {
@@ -432,7 +433,7 @@ public class SlurmComputationManager implements ComputationManager {
                     long jobId = launchSbatch(cmd);
                     if (firstJobId == null) {
                         firstJobId = jobId;
-                        taskStore.insert(workingDir.getFileName().toString(), taskCounter, firstJobId);
+                        taskStore.insert(workingDir.getFileName().toString(), firstJobId);
                         LOGGER.debug("First jobid : {}", firstJobId);
                     }
                     if (executionIndex == 0) {

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/TaskCounter.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/TaskCounter.java
@@ -12,14 +12,21 @@ import java.util.concurrent.CountDownLatch;
  * @author Yichen Tang <yichen.tang at rte-france.com>
  */
 class TaskCounter {
-    private volatile CountDownLatch latch;
 
-    TaskCounter(int totalJobs) {
+    private volatile CountDownLatch latch;
+    private volatile Boolean cancelled = false;
+
+    TaskCounter() {
+    }
+
+    void setCount(int totalJobs) {
         latch = new CountDownLatch(totalJobs);
     }
 
     void await() throws InterruptedException {
-        latch.await();
+        if (!cancelled) {
+            latch.await();
+        }
     }
 
     void countDown() {
@@ -27,6 +34,10 @@ class TaskCounter {
     }
 
     void cancel() {
+        cancelled = true;
+        if (latch == null) {
+            return;
+        }
         while (latch.getCount() > 0) {
             latch.countDown();
         }

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/TaskStore.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/TaskStore.java
@@ -90,10 +90,18 @@ class TaskStore {
         }
     }
 
-    void insert(String workingDirName, TaskCounter taskCounter, Long firstJobId) {
+    void insert(String workingDirName, TaskCounter taskCounter) {
         taskLock.writeLock().lock();
         try {
             workingDirTaskMap.put(workingDirName, taskCounter);
+        } finally {
+            taskLock.writeLock().unlock();
+        }
+    }
+
+    void insert(String workingDirName, Long firstJobId) {
+        taskLock.writeLock().lock();
+        try {
             workingDirFirstJobMap.put(workingDirName, firstJobId);
         } finally {
             taskLock.writeLock().unlock();

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/TaskStoreTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/TaskStoreTest.java
@@ -62,7 +62,8 @@ public class TaskStoreTest {
 
         TaskStore taskStore = new TaskStore();
         taskStore.insert(workingDir, future);
-        taskStore.insert(workingDir, counter, 1L);
+        taskStore.insert(workingDir, counter);
+        taskStore.insert(workingDir, 1L);
         taskStore.insertBatchIds(1L, 1L);
         if (checkTracing) {
             assertEquals(Collections.singleton(1L), taskStore.getTracingIds());


### PR DESCRIPTION
The taskCounter should be stored at first. Because a cancellation may be invoked before first job submitted.

Signed-off-by: yichen88 <tang.yichenyves@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix.


**What is the current behavior?** *(You can also link to an open issue here)*
There is a NPE on `taskCounter` if cancellation before the first job submitted.


**What is the new behavior (if this is a feature change)?**
Save the `taskCounter` at the moment it created. Then save the first job id after submitted.
Instead of save `taskCounter` with first job id.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
