### PR TITLE
Add slurm mem limit param

### DIFF
--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdBuilder.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdBuilder.java
@@ -152,6 +152,11 @@ class SbatchCmdBuilder {
         return this;
     }
 
+    SbatchCmdBuilder mem(int mem) {
+        sbatchArgsByName.put("mem", String.format("%dM", mem));
+        return this;
+    }
+
     SbatchCmd build() {
         killOnInvalidDep();
         validate();

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
@@ -486,6 +486,7 @@ public class SlurmComputationManager implements ComputationManager {
         SlurmComputationParameters extension = baseParams.getExtension(SlurmComputationParameters.class);
         if (extension != null) {
             extension.getQos().ifPresent(builder::qos);
+            extension.getMem().ifPresent(builder::mem);
         }
         baseParams.getDeadline(commandId).ifPresent(builder::deadline);
         baseParams.getTimeout(commandId).ifPresent(builder::timeout);

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationParameters.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationParameters.java
@@ -11,6 +11,7 @@ import com.powsybl.computation.ComputationParameters;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * @author Yichen TANG <yichen.tang at rte-france.com>
@@ -18,10 +19,26 @@ import java.util.Optional;
 public class SlurmComputationParameters extends AbstractExtension<ComputationParameters> {
 
     private final String qos;
+    private final Integer mem;
 
     public SlurmComputationParameters(ComputationParameters parameters, @Nullable String qos) {
+        this(parameters, qos, null);
+    }
+
+    /**
+     * Additionnal parameters for slurm
+     * @param parameters base parameters to extend
+     * @param qos name of the QOS
+     * @param mem memory usage limit (in MBytes)
+     */
+    public SlurmComputationParameters(ComputationParameters parameters, @Nullable String qos, Integer mem) {
         super(parameters);
         this.qos = qos;
+        this.mem = mem;
+    }
+
+    public OptionalInt getMem() {
+        return mem != null && mem >= 0 ? OptionalInt.of(mem) : OptionalInt.empty();
     }
 
     public Optional<String> getQos() {

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SbatchCmdTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SbatchCmdTest.java
@@ -128,4 +128,14 @@ public class SbatchCmdTest {
             assertEquals("sbatch -D /tmp/foo --job-name=testDir --kill-on-invalid-dep=yes submit.sh", cmd.toString());
         }
     }
+
+    @Test
+    public void testMem() {
+        SbatchCmdBuilder builder = new SbatchCmdBuilder();
+        SbatchCmd cmd = builder.jobName("testMem")
+                .script("submit.sh")
+                .mem(20)
+                .build();
+        assertEquals("sbatch --job-name=testMem --mem=20M --kill-on-invalid-dep=yes submit.sh", cmd.toString());
+    }
 }

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationParametersTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationParametersTest.java
@@ -27,5 +27,9 @@ public class SlurmComputationParametersTest {
         assertFalse(empty.getQos().isPresent());
         SlurmComputationParameters empty2 = new SlurmComputationParameters(base, "   ");
         assertFalse(empty2.getQos().isPresent());
+        SlurmComputationParameters sut2 = new SlurmComputationParameters(base, "aQos", 50);
+        assertSame(base, sut2.getExtendable());
+        assertEquals(50, sut2.getMem().orElse(-1));
+        assertEquals(-1, new SlurmComputationParameters(base, "aQos", -5).getMem().orElse(-1));
     }
 }


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
It's not possible to add the slurm sbatch memory limit


**What is the new behavior (if this is a feature change)?**
The slurm sbatch "--mem" has a binding through SlurmComputationParameters
