### PR TITLE
Fix fail execution in batch

### DIFF
--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/AbstractIntegrationTests.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/AbstractIntegrationTests.java
@@ -11,10 +11,17 @@ import com.powsybl.commons.config.YamlModuleConfigRepository;
 import com.powsybl.computation.AbstractExecutionHandler;
 import com.powsybl.computation.ComputationParameters;
 import com.powsybl.computation.ExecutionEnvironment;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -78,4 +85,16 @@ public abstract class AbstractIntegrationTests {
     }
 
     abstract void baseTest(Supplier<AbstractExecutionHandler<String>> supplier, ComputationParameters parameters, boolean checkClean);
+
+    static void generateZipFileOnRemote(String name, Path dest) {
+        try (InputStream inputStream = SlurmNormalExecutionTest.class.getResourceAsStream("/afile.txt");
+             ZipArchiveOutputStream zos = new ZipArchiveOutputStream(Files.newOutputStream(dest))) {
+            ZipArchiveEntry entry = new ZipArchiveEntry(name);
+            zos.putArchiveEntry(entry);
+            IOUtils.copy(inputStream, zos);
+            zos.closeArchiveEntry();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmInvalidExecutionTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmInvalidExecutionTest.java
@@ -60,6 +60,21 @@ public class SlurmInvalidExecutionTest extends AbstractIntegrationTests {
     }
 
     @Test
+    public void testInvalidInBatch() {
+        Supplier<AbstractExecutionHandler<String>> supplier = () -> new AbstractCheckErrorsExecutionHandler() {
+            @Override
+            public List<CommandExecution> before(Path workingDir) {
+                generateZipFileOnRemote("in0", workingDir.resolve("in0.zip"));
+                generateZipFileOnRemote("in1", workingDir.resolve("in1.zip"));
+                generateZipFileOnRemote("in2", workingDir.resolve("in2.zip"));
+                generateZipFileOnRemote("in3", workingDir.resolve("in3.zip"));
+                return CommandExecutionsTestFactory.myEchoSimpleCmdWithUnzipZip(4);
+            }
+        };
+        baseTest(supplier);
+    }
+
+    @Test
     public void testInvalidProgramInList() {
         Supplier<AbstractExecutionHandler<String>> supplier = () -> new AbstractCheckErrorsExecutionHandler() {
             @Override

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmNormalExecutionTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmNormalExecutionTest.java
@@ -7,16 +7,12 @@
 package com.powsybl.computation.slurm;
 
 import com.powsybl.computation.*;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.apache.commons.io.IOUtils;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,8 +25,13 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.zip.GZIPOutputStream;
 
-import static com.powsybl.computation.slurm.CommandExecutionsTestFactory.*;
-import static org.junit.Assert.*;
+import static com.powsybl.computation.slurm.CommandExecutionsTestFactory.longProgram;
+import static com.powsybl.computation.slurm.CommandExecutionsTestFactory.md5sumLargeFile;
+import static com.powsybl.computation.slurm.CommandExecutionsTestFactory.simpleCmdWithCount;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Yichen TANG <yichen.tang at rte-france.com>
@@ -259,18 +260,6 @@ public class SlurmNormalExecutionTest extends AbstractIntegrationTests {
             }
         };
         baseTest(supplier);
-    }
-
-    private static void generateZipFileOnRemote(String name, Path dest) {
-        try (InputStream inputStream = SlurmNormalExecutionTest.class.getResourceAsStream("/afile.txt");
-             ZipArchiveOutputStream zos = new ZipArchiveOutputStream(Files.newOutputStream(dest))) {
-            ZipArchiveEntry entry = new ZipArchiveEntry(name);
-            zos.putArchiveEntry(entry);
-            IOUtils.copy(inputStream, zos);
-            zos.closeArchiveEntry();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 
     private void generateGzFileOnRemote(int sizeGb, Path dest) {

--- a/computation-slurm-test/src/test/resources/myapps/myecho.sh
+++ b/computation-slurm-test/src/test/resources/myapps/myecho.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
-echo $1 > $2
+if [ $1 = "in3" ]; then
+  echoooo
+else
+  echo $1 > $2
+fi

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTask.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTask.java
@@ -78,6 +78,16 @@ public class SlurmTask {
         return firstJobId;
     }
 
+    Long getMasterId(Long batchId) {
+        for (Map.Entry<Long, SubTask> entry : subTaskMap.entrySet()) {
+            boolean contains = entry.getValue().batchIds.contains(batchId);
+            if (contains) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
     TaskCounter getCounter() {
         return counter;
     }

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/CommandExecutionsTestFactory.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/CommandExecutionsTestFactory.java
@@ -41,6 +41,11 @@ public final class CommandExecutionsTestFactory {
         return Collections.singletonList(commandExecution);
     }
 
+    /**
+     * The 4th batch would fail.
+     * @param executionCount
+     * @return
+     */
     static List<CommandExecution> myEchoSimpleCmdWithUnzipZip(int executionCount) {
         Command command = new SimpleCommandBuilder()
                 .id("myEcho")

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmTaskTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmTaskTest.java
@@ -53,7 +53,7 @@ public class SlurmTaskTest {
     public void testIdsRelationship() {
         SlurmTask task = mockSubmittedTask(mock(CompletableFuture.class));
         List<Long> masters = task.getMasters();
-        assertTrue(1L == task.getFirstJobId());
+        assertEquals(1L, (long) task.getFirstJobId());
         assertEquals(Arrays.asList(1L, 3L, 6L), masters);
         assertEquals(new HashSet<>(Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L)), task.getTracingIds());
         assertTrue(task.contains(3L));
@@ -63,6 +63,8 @@ public class SlurmTaskTest {
         // sub task
         assertEquals(Arrays.asList(4L, 5L), task.getBatches(3L));
         assertTrue(task.getBatches(6L).isEmpty());
+
+        assertEquals(3L, (long) task.getMasterId(4L));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: yichen88 <tang.yichenyves@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
1. A failed batch execution would not be detected by `sacct`.
2. Wrong execution index and exitcode.


**What is the new behavior (if this is a feature change)?**
Fix all.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
