### PR TITLE
Use scontrol instead of sacct to get status of finished tasks.

### DIFF
--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmNormalExecutionTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmNormalExecutionTest.java
@@ -64,7 +64,7 @@ public class SlurmNormalExecutionTest extends AbstractIntegrationTests {
         Supplier<AbstractExecutionHandler<String>> supplier = () -> new AbstractReturnOKExecutionHandler() {
             @Override
             public List<CommandExecution> before(Path path) {
-                return simpleCmdWithCount(7);
+                return simpleCmdWithCount(2);
             }
         };
         baseTest(supplier);
@@ -183,6 +183,17 @@ public class SlurmNormalExecutionTest extends AbstractIntegrationTests {
             @Override
             public List<CommandExecution> before(Path workingDir) {
                 return CommandExecutionsTestFactory.twoSimpleCmd();
+            }
+        };
+        baseTest(supplier);
+    }
+
+    @Test
+    public void testFoo() {
+        Supplier<AbstractExecutionHandler<String>> supplier = () -> new AbstractReturnOKExecutionHandler() {
+            @Override
+            public List<CommandExecution> before(Path workingDir) {
+                return CommandExecutionsTestFactory.mixedPrograms();
             }
         };
         baseTest(supplier);

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmCmd.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmCmd.java
@@ -6,6 +6,9 @@
  */
 package com.powsybl.computation.slurm;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Objects;
 
 /**
@@ -13,11 +16,14 @@ import java.util.Objects;
  */
 abstract class AbstractSlurmCmd<T> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSlurmCmd.class);
+
     abstract T send(CommandExecutor commandExecutor) throws SlurmCmdNonZeroException;
 
     CommandResult sendCmd(CommandExecutor commandExecutor, String cmd) throws SlurmCmdNonZeroException {
         Objects.requireNonNull(commandExecutor);
         Objects.requireNonNull(cmd);
+        LOGGER.debug("Sending cmd:" + cmd);
         CommandResult result = commandExecutor.execute(cmd);
         if (result.getExitCode() != 0) {
             throw new SlurmCmdNonZeroException(result);

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/JobArraySlurmTask.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/JobArraySlurmTask.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.regex.Matcher;
 
 /**
  *
@@ -92,22 +91,8 @@ class JobArraySlurmTask extends AbstractTask {
     }
 
     @Override
-    ExecutionError convertNonZeroSacctLine2Error(String line) {
-        Matcher m = DIGITAL_PATTERN.matcher(line);
-        m.find();
-        long jobId = Long.parseLong(m.group());
-        if (line.contains("_")) {
-            m.find();
-            int executionIdx = Integer.parseInt(m.group());
-            m.find();
-            int exitCode = Integer.parseInt(m.group());
-            return new ExecutionError(commandByJobId.get(jobId), executionIdx, exitCode);
-        } else {
-            // not array job
-            m.find();
-            int exitCode = Integer.parseInt(m.group());
-            return new ExecutionError(commandByJobId.get(jobId), 0, exitCode);
-        }
+    ExecutionError convertScontrolResult2Error(ScontrolCmd.ScontrolResultBean scontrolResultBean) {
+        return new ExecutionError(commandByJobId.get(scontrolResultBean.getJobId()), scontrolResultBean.getArrayTaskId(), scontrolResultBean.getExitCode());
     }
 
     private String prepareBatch(CommandExecution commandExecution, boolean isLastCommandExecution) throws IOException {

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
@@ -71,6 +71,7 @@ public class ScontrolMonitor extends AbstractSlurmJobMonitor {
                             job.interrupted();
                             LOGGER.info(msg);
                             break;
+                        case COMPLETING:
                         case COMPLETED:
                             // this monitor found task finished before flagDirMonitor
                             // maybe store it and recheck in next run()

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
@@ -56,7 +56,7 @@ public class ScontrolMonitor extends AbstractSlurmJobMonitor {
                 ScontrolCmd scontrolCmd = ScontrolCmdFactory.showJob(id);
                 try {
                     ScontrolCmd.ScontrolResult scontrolResult = scontrolCmd.send(commandRunner);
-                    SlurmConstants.JobState jobState = scontrolResult.getJobState();
+                    SlurmConstants.JobState jobState = scontrolResult.getResult().getJobState();
                     boolean anormal = false;
                     switch (jobState) {
                         case RUNNING:

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
@@ -128,7 +128,7 @@ public class SlurmComputationManager implements ComputationManager {
     }
 
     private void checkSlurmInstall() {
-        for (String program : new String[]{"squeue", "sinfo", "srun", "sbatch", "scontrol", "sacct"}) {
+        for (String program : new String[]{"squeue", "sinfo", "srun", "sbatch", "scontrol"}) {
             int exitCode = commandRunner.execute(program + " --help").getExitCode();
             if (exitCode != 0) {
                 throw new SlurmException("Slurm is not installed. '" + program + " --help' failed with code " + exitCode);

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmConstants.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmConstants.java
@@ -22,6 +22,7 @@ final class SlurmConstants {
         TIMEOUT,
         DEADLINE,
         CANCELLED,
+        COMPLETING,
         COMPLETED
     }
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmConstants.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmConstants.java
@@ -16,6 +16,7 @@ final class SlurmConstants {
     static final String BATCH_EXT = ".batch";
 
     enum JobState {
+        FAILED,
         PENDING,
         RUNNING,
         TIMEOUT,

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTaskImpl.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTaskImpl.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -124,12 +123,9 @@ public class SlurmTaskImpl extends AbstractTask {
     }
 
     @Override
-    ExecutionError convertNonZeroSacctLine2Error(String line) {
-        Matcher m = DIGITAL_PATTERN.matcher(line);
-        m.find();
-        long jobId = Long.parseLong(m.group());
-        m.find();
-        int exitCode = Integer.parseInt(m.group());
+    ExecutionError convertScontrolResult2Error(ScontrolCmd.ScontrolResultBean scontrolResultBean) {
+        long jobId = scontrolResultBean.getJobId();
+        int exitCode = scontrolResultBean.getExitCode();
         long mid = jobId;
         int executionIdx = 0;
         if (!commandByJobId.containsKey(jobId)) {

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/JobArraySlurmTaskTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/JobArraySlurmTaskTest.java
@@ -57,7 +57,9 @@ public class JobArraySlurmTaskTest extends DefaultSlurmTaskTest {
             fail();
         }
 
-        when(commandExecutor.execute(startsWith("sacct"))).thenReturn(simpleOutput("3_1  127:0"));
+        when(commandExecutor.execute(startsWith("scontrol show job 1"))).thenReturn(simpleOutput("JobId=1 0:0"));
+        when(commandExecutor.execute(startsWith("scontrol show job 3"))).thenReturn(simpleOutput("JobId=3 ArrayTaskId=1 ExitCode=127:0"));
+        when(commandExecutor.execute(startsWith("scontrol show job 6"))).thenReturn(simpleOutput("JobId=6 0:0"));
         getPendingJob(task, 3).failed();
         SlurmExecutionReport report = task.await();
         assertEquals(1, report.getErrors().size());

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolCmdTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolCmdTest.java
@@ -8,6 +8,8 @@ package com.powsybl.computation.slurm;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -50,8 +52,81 @@ public class ScontrolCmdTest {
         when(commandExecutor.execute("scontrol show job 41524")).thenReturn(result);
         ScontrolCmd scontrolCmd = ScontrolCmdFactory.showJob(41524);
         ScontrolCmd.ScontrolResult scontrolResult = scontrolCmd.send(commandExecutor);
-        assertEquals("test(2000)", scontrolResult.getUserId());
-        assertEquals("metrix-chunk-1", scontrolResult.getJobName());
-        assertEquals(SlurmConstants.JobState.RUNNING, scontrolResult.getJobState());
+        assertEquals("test(2000)", scontrolResult.getResult().getUserId());
+        assertEquals("metrix-chunk-1", scontrolResult.getResult().getJobName());
+        assertEquals(SlurmConstants.JobState.RUNNING, scontrolResult.getResult().getJobState());
+    }
+
+    @Test
+    public void testArray() throws SlurmCmdNonZeroException {
+        CommandExecutor commandExecutor = mock(CommandExecutor.class);
+        CommandResult result = mock(CommandResult.class);
+        when(result.getExitCode()).thenReturn(0);
+        when(result.getStdOut()).thenReturn("JobId=175667 ArrayJobId=175667 ArrayTaskId=1 JobName=cmdId\n" +
+                "   UserId=test(619800090) GroupId=test(619800090) MCS_label=N/A\n" +
+                "   Priority=1000 Nice=0 Account=test QOS=test\n" +
+                "   JobState=COMPLETED Reason=None Dependency=(null)\n" +
+                "   Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=1:0\n" +
+                "   RunTime=00:00:00 TimeLimit=2-00:00:00 TimeMin=N/A\n" +
+                "   SubmitTime=2020-10-05T14:39:01 EligibleTime=2020-10-05T14:39:01\n" +
+                "   AccrueTime=Unknown\n" +
+                "   StartTime=2020-10-05T14:39:01 EndTime=2020-10-05T14:39:01 Deadline=N/A\n" +
+                "   SuspendTime=None SecsPreSuspend=0 LastSchedEval=2020-10-05T14:39:01\n" +
+                "   Partition=calinopf AllocNode:Sid=pf9sosphpc3:12517\n" +
+                "   ReqNodeList=(null) ExcNodeList=(null)\n" +
+                "   NodeList=pf9sosrek3\n" +
+                "   BatchHost=pf9sosrek3\n" +
+                "   NumNodes=1 NumCPUs=8 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*\n" +
+                "   TRES=cpu=8,node=1,billing=8\n" +
+                "   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*\n" +
+                "   MinCPUsNode=1 MinMemoryNode=0 MinTmpDiskNode=0\n" +
+                "   Features=(null) DelayBoot=00:00:00\n" +
+                "   OverSubscribe=YES Contiguous=0 Licenses=(null) Network=(null)\n" +
+                "   Command=/home/test/yichen_slurm_unit/unit_test_3609105074134694169/cmdId.batch\n" +
+                "   WorkDir=/home/test/yichen_slurm_unit/unit_test_3609105074134694169\n" +
+                "   StdErr=/home/test/yichen_slurm_unit/unit_test_3609105074134694169/cmdId_1.err\n" +
+                "   StdIn=/dev/null\n" +
+                "   StdOut=/home/test/yichen_slurm_unit/unit_test_3609105074134694169/cmdId_1.out\n" +
+                "   Power=\n" +
+                "   KillOInInvalidDependent=Yes\n" +
+                "   MailUser=(null) MailType=NONE\n" +
+                "\n" +
+                "JobId=175668 ArrayJobId=175667 ArrayTaskId=0 JobName=cmdId\n" +
+                "   UserId=test(619800090) GroupId=test(619800090) MCS_label=N/A\n" +
+                "   Priority=1000 Nice=0 Account=test QOS=test\n" +
+                "   JobState=COMPLETED Reason=None Dependency=(null)\n" +
+                "   Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0\n" +
+                "   RunTime=00:00:00 TimeLimit=2-00:00:00 TimeMin=N/A\n" +
+                "   SubmitTime=2020-10-05T14:39:01 EligibleTime=2020-10-05T14:39:01\n" +
+                "   AccrueTime=Unknown\n" +
+                "   StartTime=2020-10-05T14:39:01 EndTime=2020-10-05T14:39:01 Deadline=N/A\n" +
+                "   SuspendTime=None SecsPreSuspend=0 LastSchedEval=2020-10-05T14:39:01\n" +
+                "   Partition=calinopf AllocNode:Sid=pf9sosphpc3:12517\n" +
+                "   ReqNodeList=(null) ExcNodeList=(null)\n" +
+                "   NodeList=pf9sosrek2\n" +
+                "   BatchHost=pf9sosrek2\n" +
+                "   NumNodes=1 NumCPUs=8 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*\n" +
+                "   TRES=cpu=8,node=1,billing=8\n" +
+                "   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*\n" +
+                "   MinCPUsNode=1 MinMemoryNode=0 MinTmpDiskNode=0\n" +
+                "   Features=(null) DelayBoot=00:00:00\n" +
+                "   OverSubscribe=YES Contiguous=0 Licenses=(null) Network=(null)\n" +
+                "   Command=/home/test/yichen_slurm_unit/unit_test_3609105074134694169/cmdId.batch\n" +
+                "   WorkDir=/home/test/yichen_slurm_unit/unit_test_3609105074134694169\n" +
+                "   StdErr=/home/test/yichen_slurm_unit/unit_test_3609105074134694169/cmdId_0.err\n" +
+                "   StdIn=/dev/null\n" +
+                "   StdOut=/home/test/yichen_slurm_unit/unit_test_3609105074134694169/cmdId_0.out\n" +
+                "   Power=\n" +
+                "   KillOInInvalidDependent=Yes\n" +
+                "   MailUser=(null) MailType=NONE\n" +
+                "\n");
+        when(commandExecutor.execute("scontrol show job 175667")).thenReturn(result);
+        ScontrolCmd scontrolCmd = ScontrolCmdFactory.showJob(175667);
+        ScontrolCmd.ScontrolResult scontrolResult = scontrolCmd.send(commandExecutor);
+        final List<ScontrolCmd.ScontrolResultBean> resultBeanList = scontrolResult.getResultBeanList();
+        assertEquals(2, resultBeanList.size());
+        final ScontrolCmd.ScontrolResultBean bean = resultBeanList.get(0);
+        assertEquals(175667, bean.getJobId());
+        assertEquals(1, bean.getExitCode());
     }
 }

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationManagerTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationManagerTest.java
@@ -104,10 +104,10 @@ public class SlurmComputationManagerTest {
         ExecutorService executorService = mock(ExecutorService.class);
         CommandExecutor runner = mock(CommandExecutor.class);
         when(runner.execute(anyString())).thenReturn(emptyResult());
-        when(runner.execute(eq("sacct --help"))).thenReturn(new CommandResult(42, "not found", "error"));
+        when(runner.execute(eq("squeue --help"))).thenReturn(new CommandResult(42, "not found", "error"));
         Assertions.assertThatThrownBy(() -> new SlurmComputationManager(config, executorService, runner, fileSystem, localDir))
                 .isInstanceOf(SlurmException.class)
-                .hasMessage("Slurm is not installed. 'sacct --help' failed with code 42");
+                .hasMessage("Slurm is not installed. 'squeue --help' failed with code 42");
     }
 
     @Before

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmTaskTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmTaskTest.java
@@ -111,7 +111,7 @@ public class SlurmTaskTest {
             fail();
         }
 
-        when(commandExecutor.execute(startsWith("sacct"))).thenReturn(CommandResultTestFactory.simpleOutput("1 127:0"));
+        when(commandExecutor.execute(startsWith("scontrol"))).thenReturn(CommandResultTestFactory.simpleOutput("JobId=1\n ExitCode=127:0"));
         SlurmExecutionReport report = task.generateReport();
         assertFalse(report.getErrors().isEmpty());
         ExecutionError executionError = report.getErrors().get(0);


### PR DESCRIPTION
The sacct command would failed when slurm DB is not accessible for some reason, and then the whole slurm computation manager could not continue to work.

From this slurm schema image(https://slurm.schedmd.com/arch.gif), the scontrol command is not depends on slurm DB.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#51 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
