### PR TITLE
Javadoc fix: add literal in mail addresses

### DIFF
--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/CommonFile.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/CommonFile.java
@@ -8,7 +8,7 @@ package com.powsybl.computation.mpi;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class CommonFile {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/Core.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/Core.java
@@ -8,7 +8,7 @@ package com.powsybl.computation.mpi;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class Core {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/CorePool.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/CorePool.java
@@ -16,7 +16,7 @@ import java.util.Set;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class CorePool {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/CsvMpiStatistics.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/CsvMpiStatistics.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CsvMpiStatistics implements MpiStatistics {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/CsvMpiStatisticsFactory.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/CsvMpiStatisticsFactory.java
@@ -12,7 +12,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CsvMpiStatisticsFactory implements MpiStatisticsFactory {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/ExportTasksStatisticsTool.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/ExportTasksStatisticsTool.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(Tool.class)
 public class ExportTasksStatisticsTool implements Tool {

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/JniMpiNativeServices.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/JniMpiNativeServices.java
@@ -9,7 +9,7 @@ package com.powsybl.computation.mpi;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class JniMpiNativeServices implements MpiNativeServices {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiComputationManager.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiComputationManager.java
@@ -24,7 +24,7 @@ import java.util.concurrent.*;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MpiComputationManager implements ComputationManager {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiComputationResourcesStatus.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiComputationResourcesStatus.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MpiComputationResourcesStatus implements ComputationResourcesStatus {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiExecutorContext.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiExecutorContext.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MpiExecutorContext {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiJob.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiJob.java
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MpiJob {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiJobScheduler.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiJobScheduler.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface MpiJobScheduler {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiJobSchedulerImpl.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiJobSchedulerImpl.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MpiJobSchedulerImpl implements MpiJobScheduler {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiMaster.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiMaster.java
@@ -18,7 +18,7 @@ import java.nio.file.FileSystems;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class MpiMaster {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiNativeServices.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiNativeServices.java
@@ -9,7 +9,7 @@ package com.powsybl.computation.mpi;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface MpiNativeServices {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiRank.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiRank.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MpiRank {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiResources.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiResources.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MpiResources {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiStatistics.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiStatistics.java
@@ -13,7 +13,7 @@ import java.time.ZonedDateTime;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface MpiStatistics extends AutoCloseable {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiStatisticsFactory.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiStatisticsFactory.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface MpiStatisticsFactory {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiTask.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiTask.java
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MpiTask {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiToolUtil.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/MpiToolUtil.java
@@ -19,7 +19,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class MpiToolUtil {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/NoMpiStatistics.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/NoMpiStatistics.java
@@ -13,7 +13,7 @@ import java.time.ZonedDateTime;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NoMpiStatistics implements MpiStatistics {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/NoMpiStatisticsFactory.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/NoMpiStatisticsFactory.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NoMpiStatisticsFactory implements MpiStatisticsFactory {
 

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/ProfiledExecutionListener.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/ProfiledExecutionListener.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class ProfiledExecutionListener implements ExecutionListener {
 

--- a/computation-mpi/src/test/java/com/powsybl/computation/mpi/CorePoolTest.java
+++ b/computation-mpi/src/test/java/com/powsybl/computation/mpi/CorePoolTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class CorePoolTest {
 

--- a/computation-mpi/src/test/java/com/powsybl/computation/mpi/MpiComputationManagerTest.java
+++ b/computation-mpi/src/test/java/com/powsybl/computation/mpi/MpiComputationManagerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MpiComputationManagerTest {
 

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/AbstractIntegrationTests.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/AbstractIntegrationTests.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public abstract class AbstractIntegrationTests {
 

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/AbstractReturnOKExecutionHandler.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/AbstractReturnOKExecutionHandler.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 abstract class AbstractReturnOKExecutionHandler extends AbstractExecutionHandler<String> {
     @Override

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmCancelExecutionTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmCancelExecutionTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 @Disabled("Slurm integration tests must be run locally.")
 class SlurmCancelExecutionTest extends AbstractIntegrationTests {

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmInvalidExecutionTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmInvalidExecutionTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 @Disabled("Slurm integration tests must be run locally.")
 class SlurmInvalidExecutionTest extends AbstractIntegrationTests {

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmNormalExecutionTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmNormalExecutionTest.java
@@ -33,7 +33,7 @@ import static com.powsybl.computation.slurm.CommandExecutionsTestFactory.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 @Disabled("Slurm integration tests must be run locally.")
 @TestMethodOrder(MethodName.class)

--- a/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmOtherCaseTest.java
+++ b/computation-slurm-test/src/test/java/com/powsybl/computation/slurm/SlurmOtherCaseTest.java
@@ -31,7 +31,7 @@ import static com.powsybl.computation.slurm.CommandExecutionsTestFactory.makeSlu
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 @Disabled("Slurm integration tests must be run locally.")
 class SlurmOtherCaseTest extends AbstractIntegrationTests {

--- a/computation-slurm/pom.xml
+++ b/computation-slurm/pom.xml
@@ -105,11 +105,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmCmd.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmCmd.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 abstract class AbstractSlurmCmd<T> {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmCmdResult.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmCmdResult.java
@@ -9,7 +9,7 @@ package com.powsybl.computation.slurm;
 import java.util.Objects;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public abstract class AbstractSlurmCmdResult implements SlurmCmdResult {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmJobMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractSlurmJobMonitor.java
@@ -17,7 +17,7 @@ import java.util.function.Supplier;
  * Abstract base class for jobs monitors, in charge of monitoring the status
  * of submitted jobs.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public abstract class AbstractSlurmJobMonitor implements Runnable {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractTask.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/AbstractTask.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.computation.slurm.SlurmConstants.BATCH_EXT;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public abstract class AbstractTask implements SlurmTask {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/CommandExecutor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/CommandExecutor.java
@@ -9,7 +9,7 @@ package com.powsybl.computation.slurm;
 /**
  * Simple interface to execute shell commands, 1 at a time.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public interface CommandExecutor extends AutoCloseable {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/CommandResult.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/CommandResult.java
@@ -12,7 +12,7 @@ import static java.util.Objects.requireNonNull;
  * The results of the execution of a shell command:
  * the exit code, and standard output and standard error as strings.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public record CommandResult(int exitCode, String stdOut, String stdErr) {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/CommandUtils.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/CommandUtils.java
@@ -13,7 +13,7 @@ import java.util.stream.Collector;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 final class CommandUtils {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ConcurrentSshCommandRunner.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ConcurrentSshCommandRunner.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 class ConcurrentSshCommandRunner extends CommandRunner {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/FlagFilesMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/FlagFilesMonitor.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A job monitor which relies on the creation of "flag" files at the end of submitted jobs.
  *
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class FlagFilesMonitor extends AbstractSlurmJobMonitor {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/JobArraySlurmTask.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/JobArraySlurmTask.java
@@ -19,7 +19,7 @@ import java.util.*;
  * A {@link SlurmTask} which submits commands as job arrays when possible,
  * in particular for commands with execution count > 1.
  *
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class JobArraySlurmTask extends AbstractTask {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/LocalCommandExecutor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/LocalCommandExecutor.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * Executes shell commands using the local OS.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 class LocalCommandExecutor implements CommandExecutor {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/MonitoredJob.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/MonitoredJob.java
@@ -11,7 +11,7 @@ package com.powsybl.computation.slurm;
  * An individual job submitted to slurm, an which completion or failure
  * needs to be monitored.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public interface MonitoredJob {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmd.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmd.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
  *
  * Sbatch scripts will be submitted using that kind of command.
  *
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public class SbatchCmd extends AbstractSlurmCmd<SbatchCmdResult> {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdBuilder.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdBuilder.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * Builds an {@link SbatchCmd}, used to submit script execution to Slurm.
  * @see <a href="https://slurm.schedmd.com/sbatch.html">Sbatch</a>
  *
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class SbatchCmdBuilder {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdResult.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchCmdResult.java
@@ -7,7 +7,7 @@
 package com.powsybl.computation.slurm;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class SbatchCmdResult extends AbstractSlurmCmdResult {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchScriptGenerator.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SbatchScriptGenerator.java
@@ -22,8 +22,8 @@ import static com.powsybl.computation.FilePreProcessor.FILE_GUNZIP;
 /**
  * Generates the content of the sbatch script, to be submitted using and {@link SbatchCmd}.
  *
- * @author Yichen Tang <yichen.tang at rte-france.com>
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 class SbatchScriptGenerator {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolCmd.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolCmd.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class ScontrolCmd extends AbstractSlurmCmd<ScontrolCmd.ScontrolResult> {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolCmdFactory.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolCmdFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.computation.slurm;
 /**
  * @see <a href="https://slurm.schedmd.com/scontrol.html">Scontrol</a>
  *
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public final class ScontrolCmdFactory {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/ScontrolMonitor.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Set;
 
 /**
- *  A job monitor which uses "scontrol show job ID_OF_JOB" to get state of job,
- *  in case, the job itself can not finish completely.
- *  (For example, scancel on slurm directly or timeout)
+ * A job monitor which uses "scontrol show job ID_OF_JOB" to get state of job,
+ * in case, the job itself can not finish completely.
+ * (For example, scancel on slurm directly or timeout)
  *
- *  @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public class ScontrolMonitor extends AbstractSlurmJobMonitor {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmCmdNonZeroException.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmCmdNonZeroException.java
@@ -7,7 +7,7 @@
 package com.powsybl.computation.slurm;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public class SlurmCmdNonZeroException extends Exception {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmCmdResult.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmCmdResult.java
@@ -7,7 +7,7 @@
 package com.powsybl.computation.slurm;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public interface SlurmCmdResult {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationConfig.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationConfig.java
@@ -15,7 +15,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SlurmComputationConfig {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManager.java
@@ -31,8 +31,8 @@ import java.util.concurrent.*;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 public class SlurmComputationManager implements ComputationManager {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManagerFactory.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationManagerFactory.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SlurmComputationManagerFactory implements ComputationManagerFactory {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationParameters.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationParameters.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public class SlurmComputationParameters extends AbstractExtension<ComputationParameters> {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationResourcesStatus.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmComputationResourcesStatus.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmComputationResourcesStatus implements ComputationResourcesStatus {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmConstants.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.computation.slurm;
 
 /**
- *  @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 final class SlurmConstants {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmException.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmException.java
@@ -10,7 +10,7 @@ import com.powsybl.commons.PowsyblException;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SlurmException extends PowsyblException {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmStatusManager.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmStatusManager.java
@@ -15,8 +15,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 class SlurmStatusManager {
     private static final String TIME_CMD = "date +\"%Y-%m-%d %H:%M:%S %Z\"";

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTask.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTask.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ExecutionException;
  * Represents a user submitted tasks, which will probably required the execution
  * of multiple underlying individual jobs on the slurm infrastructure.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public interface SlurmTask {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTaskImpl.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmTaskImpl.java
@@ -25,7 +25,7 @@ import static com.powsybl.computation.slurm.SlurmConstants.BATCH_EXT;
  * This class contains those job ids relationship in Slurm platform for one task.
  * It has a correspondent working directory and the CompletableFuture as return value.
  *
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public class SlurmTaskImpl extends AbstractTask {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmUtils.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SlurmUtils.java
@@ -9,7 +9,7 @@ package com.powsybl.computation.slurm;
 import com.google.common.base.Preconditions;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 final class SlurmUtils {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/SshCommandExecutor.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/SshCommandExecutor.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * Executes shell commands through an SSH connection,
  * using an underlying JSCH {@link CommandRunner}.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 class SshCommandExecutor implements CommandExecutor {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/TaskStore.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/TaskStore.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class TaskStore {
 

--- a/computation-slurm/src/main/java/com/powsybl/computation/slurm/UncheckedJSchException.java
+++ b/computation-slurm/src/main/java/com/powsybl/computation/slurm/UncheckedJSchException.java
@@ -10,7 +10,7 @@ import com.jcraft.jsch.JSchException;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UncheckedJSchException extends RuntimeException {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/AbstractDefaultSlurmTaskTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/AbstractDefaultSlurmTaskTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public abstract class AbstractDefaultSlurmTaskTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/CommandExecutionsTestFactory.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/CommandExecutionsTestFactory.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public final class CommandExecutionsTestFactory {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/CommandResultTestFactory.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/CommandResultTestFactory.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 final class CommandResultTestFactory {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/FlagFilesMonitorTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/FlagFilesMonitorTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class FlagFilesMonitorTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/JobArraySlurmTaskTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/JobArraySlurmTaskTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class JobArraySlurmTaskTest extends AbstractDefaultSlurmTaskTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SbatchCmdTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SbatchCmdTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SbatchCmdTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SbatchScriptGeneratorTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SbatchScriptGeneratorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class SbatchScriptGeneratorTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolCmdTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolCmdTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class ScontrolCmdTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolMonitorTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/ScontrolMonitorTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class ScontrolMonitorTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationConfigTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationConfigTest.java
@@ -21,7 +21,7 @@ import java.nio.file.FileSystem;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 class SlurmComputationConfigTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationManagerTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationManagerTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmComputationManagerTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationParametersTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmComputationParametersTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmComputationParametersTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmExecutionReportTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmExecutionReportTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmExecutionReportTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmStatusManagerTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmStatusManagerTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.startsWith;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmStatusManagerTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmTaskTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmTaskTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmTaskTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmUtilsTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/SlurmUtilsTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 class SlurmUtilsTest {
 

--- a/computation-slurm/src/test/java/com/powsybl/computation/slurm/TaskStoreTest.java
+++ b/computation-slurm/src/test/java/com/powsybl/computation/slurm/TaskStoreTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Yichen Tang <yichen.tang at rte-france.com>
+ * @author Yichen Tang {@literal <yichen.tang at rte-france.com>}
  */
 class TaskStoreTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,12 @@
         <java.version>17</java.version>
 
         <commonsexec.version>1.4.0</commonsexec.version>
-        <jsch.version>0.2.16</jsch.version>
+        <jsch.version>0.2.17</jsch.version>
         <jsch.extension.version>0.1.11</jsch.extension.version>
         <jsch.nio.version>1.0.14</jsch.nio.version>
-        <junit-jupiter.version>5.10.1</junit-jupiter.version>
-        <logback.version>1.4.14</logback.version>
-        <mockito.version>5.10.0</mockito.version>
+        <junit-jupiter.version>5.10.2</junit-jupiter.version>
+        <logback.version>1.5.6</logback.version>
+        <mockito.version>5.11.0</mockito.version>
         <protobuf.version>3.25.3</protobuf.version>
 
         <sonar.coverage.jacoco.xmlReportPaths>
@@ -71,7 +71,7 @@
             ../../distribution-hpc/target/site/jacoco-aggregate/jacoco.xml,
         </sonar.coverage.jacoco.xmlReportPaths>
 
-        <powsyblcore.version>6.3.0</powsyblcore.version>
+        <powsyblcore.version>6.3.1</powsyblcore.version>
     </properties>
 
     <dependencyManagement>
@@ -144,6 +144,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Same as https://github.com/powsybl/powsybl-core/pull/2753

**What kind of change does this PR introduce?**
Javadoc update

**What is the current behavior?**
Mail addresses were written as  `@author Name Surname <author at email.address>`

**What is the new behavior (if this is a feature change)?**
Mail addresses are written as  `@author Name Surname {@literal <author at email.address>}`

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No